### PR TITLE
`data-bem` instead `onclick`

### DIFF
--- a/src/BH.php
+++ b/src/BH.php
@@ -565,7 +565,7 @@ class BH {
                         $this->attrEscape(str_replace('[]', '{}',
                             json_encode($jsParams, JSON_UNESCAPED_UNICODE)));
                     $attrs .= ' ' . (key_exists('jsAttr', $json) ? $json->jsAttr : $this->_optJsAttrName) . '="' .
-                        ($this->_optJsAttrIsJs ? $jsData : $jsData) . '"';
+                        ($this->_optJsAttrIsJs && $this->_optJsAttrName === 'onclick' ? 'return '. $jsData : $jsData) . '"';
                 }
             }
 

--- a/src/BH.php
+++ b/src/BH.php
@@ -51,7 +51,7 @@ class BH {
      * @var array
      */
     protected $_options = [];
-    protected $_optJsAttrName = 'onclick';
+    protected $_optJsAttrName = 'data-bem';
     protected $_optJsAttrIsJs = true;
     protected $_optEscapeContent = false;
 
@@ -565,7 +565,7 @@ class BH {
                         $this->attrEscape(str_replace('[]', '{}',
                             json_encode($jsParams, JSON_UNESCAPED_UNICODE)));
                     $attrs .= ' ' . (key_exists('jsAttr', $json) ? $json->jsAttr : $this->_optJsAttrName) . '="' .
-                        ($this->_optJsAttrIsJs ? 'return ' . $jsData : $jsData) . '"';
+                        ($this->_optJsAttrIsJs ? $jsData : $jsData) . '"';
                 }
             }
 


### PR DESCRIPTION
По-умолчанию i-bem.js смотрит аттрибут `data-bem`, - логично, что и тут лучше сделать так. В документации тоже используется `data-bem` https://ru.bem.info/technology/i-bem/v2/i-bem-js/.

Поправил, чтобы при `_optJsAttrName != "onclick"` значение было без `"return"`,например ` data-bem='{ "my-block": { "name": "ya" } }'` вместо  `data-bem='return { "my-block": { "name": "ya" } }'`

не знаю как прикрепить к https://github.com/bem/bh-php/pull/14